### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,14 @@
 html, body {
   height: 100%;
 }
-
+.modal-dialog-fluid {}
+@media only screen and (max-device-width: 480px) {
+  .modal-dialog-fluid {
+    max-width: inherit;
+    width: 98%;
+    margin-left: 15px;
+  }
+}
 </style>
 </head>
 <body style="    
@@ -57,7 +64,7 @@ align-self: flex-start;
       </div>
 
       <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog" role="document">
+        <div class="modal-dialog modal-dialog-fluid" role="document">
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title" id="exampleModalLabel">Result</h5>


### PR DESCRIPTION
スマホで見るとダイアログがちっちゃい

https://getbootstrap.jp/docs/4.2/components/modal/#optional-sizes
設定無しならdefaultの500pxs

https://www.e-pokke.com/blog/bootstrap4-modal-width.html
https://hajipion.com/1134.html
モバイルサイズなら画面サイズまでダイアログを拡大するよう修正